### PR TITLE
remove weird check causing uploadBitmapData not working when starling is not rendering

### DIFF
--- a/starling/textures/ConcreteTexture.hx
+++ b/starling/textures/ConcreteTexture.hx
@@ -107,13 +107,6 @@ class ConcreteTexture extends Texture
      * cropped or filled up with transparent pixels */
     public function uploadBitmapData(data:BitmapData, async:Dynamic=null):Void
     {
-        if (!Starling.current.isRendering && !SystemUtil.isDesktop)
-        {
-            trace("[Starling] Warning: uploading bitmap data while Starling is not rendering " +
-                  "may cause a crash on some platforms. Ignoring request.");
-            return;
-        }
-		
 		var doAsync:Bool = false;
         if (Reflect.isFunction(async))
         {


### PR DESCRIPTION
the warning does not make sense - surely we can upload textures when we have a context. this might be some weird workaround for a particular Flash bug, but it's not even present in the latest AS3 Starling version, so let's just remove it