### PR TITLE
fix offscreen batching

### DIFF
--- a/starling/core/Starling.hx
+++ b/starling/core/Starling.hx
@@ -543,11 +543,9 @@ class Starling extends EventDispatcher
             mClippedViewPort.width  / scaleX,
             mClippedViewPort.height / scaleY,
             mStage.stageWidth, mStage.stageHeight, mStage.cameraPosition);
-        
-        mSupport.batcher.setViewport(mViewPort.x, mViewPort.y, mViewPort.width, mViewPort.height);
 
         if (!mShareContext)
-            RenderSupport._clear(mStage.color, 1.0);
+            mSupport.clear(mStage.color, 1.0);
         
         mStage.render(mSupport, 1.0);
         mSupport.finishQuadBatch();

--- a/starling/filters/FragmentFilter.hx
+++ b/starling/filters/FragmentFilter.hx
@@ -120,8 +120,9 @@ class FragmentFilter
     /** Helper objects that may be used recursively (thus not static). */
     private var mHelperMatrix:Matrix     = new Matrix();
     private var mHelperMatrix3D:Matrix3D = new Matrix3D();
-    private var mHelperRect:Rectangle    = new Rectangle();
+    private var mHelperRect1:Rectangle   = new Rectangle();
     private var mHelperRect2:Rectangle   = new Rectangle();
+    private var mHelperRect3:Rectangle   = new Rectangle();
 
     /** Creates a new Fragment filter with the specified number of passes and resolution.
      * This constructor may only be called by the constructor of a subclass. */
@@ -215,8 +216,9 @@ class FragmentFilter
         var scale:Float = Starling.current.contentScaleFactor;
         var projMatrix:Matrix     = mHelperMatrix;
         var projMatrix3D:Matrix3D = mHelperMatrix3D;
-        var bounds:Rectangle      = mHelperRect;
-        var boundsPot:Rectangle   = mHelperRect2;
+        var viewRect:Rectangle    = mHelperRect1;
+        var bounds:Rectangle      = mHelperRect2;
+        var boundsPot:Rectangle   = mHelperRect3;
         var previousStencilRefValue:UInt;
         var previousRenderTarget:Texture;
         var intersectWithStage:Bool;
@@ -246,6 +248,7 @@ class FragmentFilter
         // save original state (projection matrix, render target, stencil reference value)
         projMatrix.copyFrom(support.projectionMatrix);
         projMatrix3D.copyFrom(support.projectionMatrix3D);
+        viewRect.copyFrom(support.viewRect);
         previousRenderTarget = support.renderTarget;
         previousStencilRefValue = support.stencilReferenceValue;
 
@@ -300,9 +303,10 @@ class FragmentFilter
                     support.popClipRect();
                     support.projectionMatrix = projMatrix;
                     support.projectionMatrix3D = projMatrix3D;
+                    support.viewRect = viewRect;
                     support.renderTarget = previousRenderTarget;
-                    support.translateMatrix(mOffsetX, mOffsetY);
                     support.stencilReferenceValue = previousStencilRefValue;
+                    support.translateMatrix(mOffsetX, mOffsetY);
                     support.blendMode = object.blendMode;
                     support.applyBlendMode(PMA);
                 }
@@ -333,7 +337,9 @@ class FragmentFilter
             support.popClipRect();
             support.projectionMatrix = projMatrix;
             support.projectionMatrix3D = projMatrix3D;
+            support.viewRect = viewRect;
             support.renderTarget = previousRenderTarget;
+            support.stencilReferenceValue = previousStencilRefValue;
             
             // Create an image containing the cache. To have a display object that contains
             // the filter output in object coordinates. That way we can modify it with a transformation matrix.


### PR DESCRIPTION
brief summary of the rendering pipeline:
1) local space (next: model matrix)
2) world space (next: view matrix)
3) view/eye/camera space (next: projection matrix)
4) homogenous clip space (next: perspective division)
5) NDC space (next: viewport transform)
6) screen/raster space

and now?
- regular clipping takes place in step 5, here the rendering pipeline discards all vertices outside the (-1, 1) range
- the batcher processes quads in view space coordinates (see step 3)
- and the batcher tries to be smart by discarding vertices outside of the projection frustum (before even uploading offscreen vertices)

sounds good, but what is the problem?
- the problem is that it's hard to tell if an arbitrary quad is inside/outside of the frustum
- and why would you try to rewrite the rendering pipeline math on CPU level...

and now?
- the batcher takes advantage from the fact that it only handles 2D quads
- and it takes advantage from the fact that OpenFL uses an orthogonal projection for display list rendering (2D projection)
- in this environment it becomes a simple rectangle test to discard quads outside of the frustum
- the batcher calls this rectangle "viewport"

perfect, anything left?
- Starling uses a perspective projection (3D projection), but luckily it also renders 2D quads for most things
- and the plane of such quads, even in a perspective projection, again is a rectangle

ok, but why all these facts?
- first the term "viewport" isn't ideal, as it's already used by the rendering pipeline (see step 5)
- second it can lead to the misunderstanding that the "viewport" of the batcher is (or must be) equal to the GL viewport

and now?
- while the second actually is valid for orthogonal fullscreen backbuffer rendering, it's not for render targets
- it's important to understand that the clipping rectangle always is a plane of the frustum (and not the GL viewport)
- and that's why it always needs to be updated whenever the frustum changes
- I also recommend to call it "view rect" (as it's the "view space" rectangle used to construct the frustum)

and what is changed now?
- whenever the frustum changes, the "view rect" is updated as well now
- that way, no matter if offscreen or onscreen, all quads are rendered or clipped properly